### PR TITLE
feat: actions for connections pool feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# SQLite files
+*.db

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-collapsible": "^1.1.0",
+    "@radix-ui/react-context-menu": "^2.2.1",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-icons": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-collapsible':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.1
+        version: 2.2.1(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -401,6 +404,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.1':
+    resolution: {integrity: sha512-wvMKKIeb3eOrkJ96s722vcidZ+2ZNfcYZWBPRHIB1VWrF+fiF851Io6LX0kmK5wTDQFKdulCCKJk2c3SBaQHvA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.0':
@@ -2740,6 +2756,20 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.5
+
+  '@radix-ui/react-context-menu@2.2.1(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.5)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.5)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.5)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.5
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-context@1.1.0(@types/react@18.3.5)(react@18.3.1)':
     dependencies:

--- a/src/app/(main)/connections/_components/connection-table.tsx
+++ b/src/app/(main)/connections/_components/connection-table.tsx
@@ -89,13 +89,17 @@ export default function ConnectionTableServer() {
           <TableBody>
             {connections.map((conn) => (
               <TableRow key={conn.name}>
-                {["name", "host", "username", "password", " dc", "nodes"].map(
+                {["name", "host", "username", "password", "dc", "nodes"].map(
                   (key) => (
                     <ContextMenu key={`${conn.name}-${key}`}>
                       <ContextMenuTrigger asChild>
                         <TableCell>
-                          {key === "password" ? "••••••••" : (conn as any)[key]}
-                        </TableCell>
+                          {key === "password"
+                            ? "••••••••"
+                            : key === "dc" // since dc will be retrived from the driver it is hardcoded for now
+                            ? 3
+                            : (conn as any)[key]}
+                        </TableCell>  
                       </ContextMenuTrigger>
                       <ContextMenuContent>
                         <ContextMenuItem

--- a/src/app/(main)/connections/_components/connection-table.tsx
+++ b/src/app/(main)/connections/_components/connection-table.tsx
@@ -94,12 +94,8 @@ export default function ConnectionTableServer() {
                     <ContextMenu key={`${conn.name}-${key}`}>
                       <ContextMenuTrigger asChild>
                         <TableCell>
-                          {key === "password"
-                            ? "••••••••"
-                            : key === "dc" // since dc will be retrived from the driver it is hardcoded for now
-                            ? 3
-                            : (conn as any)[key]}
-                        </TableCell>  
+                          {key === "password" ? "••••••••" : (conn as any)[key]}
+                        </TableCell>
                       </ContextMenuTrigger>
                       <ContextMenuContent>
                         <ContextMenuItem

--- a/src/app/(main)/connections/_components/modal.tsx
+++ b/src/app/(main)/connections/_components/modal.tsx
@@ -11,19 +11,25 @@ import {
 import { Input } from "@scylla-studio/components/ui/input";
 import { Modal } from "@scylla-studio/components/ui/modal";
 import { Plus } from "lucide-react";
-import React from "react";
 import { ReactNode, useEffect, useState, useTransition } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
-const formSchema = z.object({
-  name: z.string().min(1, { message: "Name is required." }),
-  host: z.string().ip(),
-  username: z.string().min(1, { message: "Username is required." }),
-  password: z.string().min(1, { message: "Password is required." }),
-  dc: z.string().min(1, { message: "Data center (DC) is required." }),
-  nodes: z.number().min(1, { message: "Nodes must be at least 1." }),
-});
+const formSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, { message: "Name is required." })
+      .refine((value) => !/\s/.test(value), {
+        message: "Name cannot contain spaces.",
+      }),
+    host: z.string().ip(),
+    username: z.string().min(1, { message: "Username is required." }),
+    password: z.string().min(1, { message: "Password is required." }),
+    nodes: z.number().min(1, { message: "Nodes must be at least 1." }),
+  })
+  .required();
 
 interface FormWrapperProps {
   children: ReactNode;

--- a/src/app/(main)/connections/_components/modal.tsx
+++ b/src/app/(main)/connections/_components/modal.tsx
@@ -11,6 +11,7 @@ import {
 import { Input } from "@scylla-studio/components/ui/input";
 import { Modal } from "@scylla-studio/components/ui/modal";
 import { Plus } from "lucide-react";
+import React from "react";
 import { ReactNode, useEffect, useState, useTransition } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";

--- a/src/app/(main)/connections/_components/modal.tsx
+++ b/src/app/(main)/connections/_components/modal.tsx
@@ -17,15 +17,15 @@ import { z } from "zod";
 
 const formSchema = z
   .object({
-    name: z
+    name: z.string().trim().min(1, { message: "Name is required." }),
+    host: z.string().ip(),
+    username: z
       .string()
       .trim()
-      .min(1, { message: "Name is required." })
+      .min(1, { message: "Username is required." })
       .refine((value) => !/\s/.test(value), {
         message: "Name cannot contain spaces.",
       }),
-    host: z.string().ip(),
-    username: z.string().min(1, { message: "Username is required." }),
     password: z.string().min(1, { message: "Password is required." }),
     nodes: z.number().min(1, { message: "Nodes must be at least 1." }),
   })
@@ -138,19 +138,6 @@ export default function NewConnectionModal({
                       placeholder="Enter password"
                       {...field}
                     />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              name="dc"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Data Center</FormLabel>
-                  <FormControl>
-                    <Input placeholder="Enter data center" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/app/(main)/connections/_components/modal.tsx
+++ b/src/app/(main)/connections/_components/modal.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@scylla-studio/components/ui/button";
 import {
@@ -13,16 +11,13 @@ import {
 import { Input } from "@scylla-studio/components/ui/input";
 import { Modal } from "@scylla-studio/components/ui/modal";
 import { Plus } from "lucide-react";
-import { ReactNode, useState, useTransition } from "react";
+import { ReactNode, useEffect, useState, useTransition } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
 const formSchema = z.object({
   name: z.string().min(1, { message: "Name is required." }),
-  host: z
-    .string()
-    .min(1, { message: "Host is required." })
-    .regex(/^[a-zA-Z0-9.-]+$/, "Invalid host format."),
+  host: z.string().ip(),
   username: z.string().min(1, { message: "Username is required." }),
   password: z.string().min(1, { message: "Password is required." }),
   dc: z.string().min(1, { message: "Data center (DC) is required." }),
@@ -32,19 +27,13 @@ const formSchema = z.object({
 interface FormWrapperProps {
   children: ReactNode;
   onSubmit: (data: z.infer<typeof formSchema>) => void;
+  defaultValues?: Partial<z.infer<typeof formSchema>>;
 }
 
-function FormWrapper({ children, onSubmit }: FormWrapperProps) {
+function FormWrapper({ children, onSubmit, defaultValues }: FormWrapperProps) {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
-      name: "",
-      host: "",
-      username: "",
-      password: "",
-      dc: "",
-      nodes: 0,
-    },
+    defaultValues,
   });
 
   return (
@@ -56,9 +45,23 @@ function FormWrapper({ children, onSubmit }: FormWrapperProps) {
   );
 }
 
-export default function NewConnectionModal({ onSave }) {
+interface NewConnectionModalProps {
+  onSave: (data: z.infer<typeof formSchema>) => Promise<void>;
+  connectionToEdit?: Partial<z.infer<typeof formSchema>> | null;
+}
+
+export default function NewConnectionModal({
+  onSave,
+  connectionToEdit,
+}: NewConnectionModalProps) {
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (connectionToEdit) {
+      setOpen(true);
+    }
+  }, [connectionToEdit]);
 
   const handleSave = (data: z.infer<typeof formSchema>) => {
     startTransition(async () => {
@@ -73,7 +76,10 @@ export default function NewConnectionModal({ onSave }) {
         <Plus className="mr-2 h-4 w-4" /> New Connection
       </Button>
       <Modal open={open} onClose={() => setOpen(false)}>
-        <FormWrapper onSubmit={handleSave}>
+        <FormWrapper
+          onSubmit={handleSave}
+          defaultValues={connectionToEdit || undefined}
+        >
           <div className="space-y-5">
             <FormField
               name="name"
@@ -135,7 +141,7 @@ export default function NewConnectionModal({ onSave }) {
               name="dc"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>DC</FormLabel>
+                  <FormLabel>Data Center</FormLabel>
                   <FormControl>
                     <Input placeholder="Enter data center" {...field} />
                   </FormControl>
@@ -158,17 +164,17 @@ export default function NewConnectionModal({ onSave }) {
                         const value = e.target.value;
                         field.onChange(value === "" ? "" : Number(value));
                       }}
-                      value={field.value === "" ? "" : field.value.toString()}
                     />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
+
+            <Button type="submit" disabled={isPending}>
+              {connectionToEdit ? "Update Connection" : "Save Connection"}
+            </Button>
           </div>
-          <Button type="submit" className="mt-4" disabled={isPending}>
-            {isPending ? "Saving..." : "Save"}
-          </Button>
         </FormWrapper>
       </Modal>
     </>

--- a/src/app/(main)/connections/actions/connections.ts
+++ b/src/app/(main)/connections/actions/connections.ts
@@ -3,7 +3,9 @@
 import {
   addConnection,
   connection,
+  deleteConnectionById,
   getAllConnections,
+  updateConnectionById,
 } from "@scylla-studio/lib/internal-db/connections";
 
 export async function fetchConnections(): Promise<connection[]> {
@@ -12,4 +14,18 @@ export async function fetchConnections(): Promise<connection[]> {
 
 export async function saveNewConnection(newConnection: connection) {
   await addConnection(newConnection);
+}
+
+export async function updateConnection(
+  connectionId: number,
+  updatedConnection: connection
+) {
+  await updateConnectionById(connectionId, updatedConnection);
+}
+
+export async function deleteConnection(connectionId: number) {
+  if (!connectionId) {
+    throw new Error("Connection ID is required to delete.");
+  }
+  await deleteConnectionById(connectionId);
 }

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,204 @@
+"use client"
+
+import * as React from "react"
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
+import {
+  CheckIcon,
+  ChevronRightIcon,
+  DotFilledIcon,
+} from "@radix-ui/react-icons"
+
+import { cn } from "@scylla-studio/lib/utils"
+
+const ContextMenu = ContextMenuPrimitive.Root
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger
+
+const ContextMenuGroup = ContextMenuPrimitive.Group
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal
+
+const ContextMenuSub = ContextMenuPrimitive.Sub
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRightIcon className="ml-auto h-4 w-4" />
+  </ContextMenuPrimitive.SubTrigger>
+))
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+))
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+))
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <DotFilledIcon className="h-4 w-4 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+))
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName
+
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+))
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName
+
+const ContextMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+ContextMenuShortcut.displayName = "ContextMenuShortcut"
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}

--- a/src/lib/internal-db/connections.ts
+++ b/src/lib/internal-db/connections.ts
@@ -57,6 +57,6 @@ export type connection = {
   host: string;
   username: string;
   password: string;
-  dc: string;
+  dc?: string;
   nodes: number;
 };

--- a/src/lib/internal-db/connections.ts
+++ b/src/lib/internal-db/connections.ts
@@ -9,7 +9,7 @@ db.exec(`
     host TEXT,
     username TEXT,
     password TEXT,
-    dc TEXT,
+    dc INTEGER,
     nodes INTEGER
   )
 `);
@@ -28,7 +28,7 @@ export function addConnection(connection: connection) {
     INSERT INTO connections (name, host, username, password, dc, nodes)
     VALUES (?, ?, ?, ?, ?, ?)
   `);
-  stmt.run(name, host, username, password, dc, nodes);
+  stmt.run(name, host, username, password, 3, nodes);
 }
 
 export function updateConnectionById(

--- a/src/lib/internal-db/connections.ts
+++ b/src/lib/internal-db/connections.ts
@@ -15,7 +15,11 @@ db.exec(`
 `);
 
 export function getAllConnections(): connection[] {
-  return db.prepare("SELECT * FROM connections").all() as connection[];
+  return db
+    .prepare(
+      "SELECT id, name, host, username, password, dc, nodes FROM connections"
+    )
+    .all() as connection[];
 }
 
 export function addConnection(connection: connection) {
@@ -27,8 +31,28 @@ export function addConnection(connection: connection) {
   stmt.run(name, host, username, password, dc, nodes);
 }
 
+export function updateConnectionById(
+  connectionId: number,
+  updatedConnection: connection
+) {
+  const { name, host, username, password, dc, nodes } = updatedConnection;
+  const stmt = db.prepare(`
+    UPDATE connections
+    SET name = ?, host = ?, username = ?, password = ?, dc = ?, nodes = ?
+    WHERE id = ?
+  `);
+  stmt.run(name, host, username, password, dc, nodes, connectionId);
+}
+
+export function deleteConnectionById(connectionId: number) {
+  const stmt = db.prepare(`
+    DELETE FROM connections WHERE id = ?
+  `);
+  stmt.run(connectionId);
+}
+
 export type connection = {
-  id: number;
+  id?: number;
   name: string;
   host: string;
   username: string;


### PR DESCRIPTION
This PR propose a new feature rather than addressing any specific issue, it uses the `Context Menu` component to add update and delete capabilities to users. 

It's triggered by right-clicking on the desired row, I thought about using the "three dot" icon but this approach seemed more flexible and let's the door open to others actions. But if you'd prefer the icon-based method I'd be glad to make that change. 

## How it looks?

![Screencast from 2024-09-30 17-01-36](https://github.com/user-attachments/assets/08c44098-4d3d-473b-82c0-f67a30205e18)
