### PR TITLE
fix: contributors external images

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,19 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ["@lambda-group/scylladb"],
   },
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "github.com",
+      },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -66,6 +66,7 @@ function DashboardHeader() {
         src="https://github.com/basementdevs/scylla-studio/raw/main/.github/assets/logo.png"
         alt="ScyllaDB Studio Logo"
         width="100"
+        height="100"
       />
       <div>
         <CardHeader>
@@ -192,6 +193,8 @@ const DashboardContributors = () => {
                 src={contributor.avatarUrl}
                 alt={`${contributor.name}'s avatar`}
                 className="w-full h-48 object-cover"
+                width="100"
+                height="100"
               />
               {contributor.openToWork && (
                 <div className="absolute top-2 left-2 bg-green-500 text-white text-xs py-1 px-2 rounded-md">


### PR DESCRIPTION
Address #34 issue

Next.js's Image component must have all remote resources explicit declared in `next.config.js` [[1]](https://nextjs.org/docs/messages/next-image-unconfigured-host),  moreover props `height` and `width` are required. 