### PR TITLE
fix: metrics auto-refresh when a query is executed

### DIFF
--- a/src/app/(main)/query-runner/_components/cql-editor.tsx
+++ b/src/app/(main)/query-runner/_components/cql-editor.tsx
@@ -49,6 +49,7 @@ export function CqlEditor() {
 	const [queryTracing, setQueryTracing] = useState<TracingResult>(
 		{} as TracingResult,
 	);
+	const [updateKey, setUpdateKey] = useState(0); // Used to force re-render when query is executed
 	const [activeTab, setActiveTab] = useState<string>(DisplayTabs.RESULT);
 	const currentConnection = useCqlFilters((state) => state.currentConnection);
 	const fetchSize = useCqlFilters((state) => state.fetchSize);
@@ -64,6 +65,7 @@ export function CqlEditor() {
 		onSuccess: ({ data }) => {
 			setQueryResult(data?.result ?? []);
 			setQueryTracing(data?.tracing ?? ({} as TracingResult));
+			setUpdateKey((prev) => prev + 1); // Increment key to force re-render
 		},
 		onError: ({ error }) => {
 			console.error("Failed to execute query", error);
@@ -204,12 +206,36 @@ export function CqlEditor() {
 		}
 	};
 
-	const renderTabs = {
-		[DisplayTabs.RESULT]: (
-			<ResultsRender data={queryResult} tracingData={queryTracing} />
+	const renderResult = useCallback(
+		() => (
+			<ResultsRender
+				key={`result-${updateKey}`}
+				data={queryResult}
+				tracingData={queryTracing}
+			/>
 		),
-		[DisplayTabs.TRACING]: <TracingRender data={queryTracing} />,
-		[DisplayTabs.DASHBOARD]: <QueryDashboard tracingInfo={queryTracing} />,
+		[queryResult, queryTracing, updateKey],
+	);
+
+	const renderTracing = useCallback(
+		() => <TracingRender key={`tracing-${updateKey}`} data={queryTracing} />,
+		[queryTracing, updateKey],
+	);
+
+	const renderDashboard = useCallback(
+		() => (
+			<QueryDashboard
+				key={`dashboard-${updateKey}`}
+				tracingInfo={queryTracing}
+			/>
+		),
+		[queryTracing, updateKey],
+	);
+
+	const renderTabs = {
+		[DisplayTabs.RESULT]: renderResult(),
+		[DisplayTabs.TRACING]: renderTracing(),
+		[DisplayTabs.DASHBOARD]: renderDashboard(),
 	};
 
 	return (


### PR DESCRIPTION
Resolve the #15 issue by updating the query metrics when the query is executed without changing tabs. 

[Screencast from 2024-10-22 22-12-47.webm](https://github.com/user-attachments/assets/41d26da7-0783-4d9a-b196-76665eea4c55)

It was archived by using a counter in key to force re-rendering, I don't know if there is a better way so I'm glad to discuss.