### PR TITLE
Fix connection delete and change table actions UX

### DIFF
--- a/src/actions/query-keyspaces.ts
+++ b/src/actions/query-keyspaces.ts
@@ -3,7 +3,7 @@
 import { actionClient } from "@scylla-studio/lib/safe-actions";
 import { z } from "zod";
 
-import { Auth, Cluster, ClusterConfig } from "@lambda-group/scylladb";
+import { type Auth, Cluster } from "@lambda-group/scylladb";
 import { parseKeyspaces } from "@scylla-studio/lib/cql-parser/parser";
 
 export const queryKeyspaceAction = actionClient

--- a/src/app/(main)/connections/_components/connection-table.tsx
+++ b/src/app/(main)/connections/_components/connection-table.tsx
@@ -11,6 +11,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@scylla-studio/components/ui/context-menu";
+import { Skeleton } from "@scylla-studio/components/ui/skeleton";
 import {
   Table,
   TableBody,
@@ -19,61 +20,63 @@ import {
   TableHeader,
   TableRow,
 } from "@scylla-studio/components/ui/table";
+import { useConnectionsStore } from "@scylla-studio/hooks/use-connections";
 import type { Connection } from "@scylla-studio/lib/internal-db/connections";
-import { useEffect, useState, useTransition } from "react";
-import {
-  deleteConnection,
-  fetchConnections,
-  saveNewConnection,
-  updateConnection,
-} from "../actions/connections";
+import { useEffect, useTransition } from "react";
+import { toast } from "sonner";
 import NewConnectionModal from "./modal";
+import { RowActions } from "./row-actions";
 import TableLabel from "./table-item";
 
 export default function ConnectionTableServer() {
-  const [connections, setConnections] = useState<Connection[]>([]);
-  const [selectedConnection, setSelectedConnection] =
-    useState<Connection | null>(null);
+  const {
+    availableConnections,
+    loadingConnections,
+    currentConnection,
+    getConnections,
+    deleteConnection,
+    refreshConnection,
+    saveConnection,
+    setCurrentConnection,
+    updateConnection,
+  } = useConnectionsStore();
+
   const [_, startTransition] = useTransition();
 
   useEffect(() => {
     startTransition(async () => {
-      const initialConnections = await fetchConnections();
-      setConnections(initialConnections);
+      await getConnections();
     });
   }, []);
 
   const handleSave = async (newConnection: Connection) => {
-    startTransition(async () => {
-      await (selectedConnection && selectedConnection?.id
-        ? updateConnection(selectedConnection.id, newConnection)
-        : saveNewConnection(newConnection));
-      const updatedConnections = await fetchConnections();
-      setConnections(updatedConnections);
-      setSelectedConnection(null);
-    });
+    return currentConnection && currentConnection?.id
+      ? await updateConnection(currentConnection.id, newConnection)
+      : await saveConnection(newConnection);
   };
 
   const handleDelete = async (conn: Connection) => {
-    if (conn?.id) {
-      startTransition(async () => {
-        await deleteConnection(conn.id!);
-        const updatedConnections = await fetchConnections();
-        setConnections(updatedConnections);
-      });
+    try {
+      await deleteConnection(conn);
+      toast.success("Connection deleted successfully");
+    } catch (error) {
+      console.error("[ConnectionTableServer.handleDelete]", error);
+      toast.error("Error deleting connection, please try again later");
     }
   };
 
   const handleRefresh = async (conn: Connection) => {
-    startTransition(async () => {
-      await updateConnection(conn.id!, conn);
-      const updatedConnection = await fetchConnections();
-      setConnections(updatedConnection);
-    });
+    try {
+      await refreshConnection(conn);
+      toast.success("Connection refreshed successfully");
+    } catch (error) {
+      console.error("[ConnectionTableServer.handleRefresh]", error);
+      toast.error("Error refreshing connection, please try again later");
+    }
   };
 
   const handleUpdateClick = (conn: Connection) => {
-    setSelectedConnection(conn);
+    setCurrentConnection(conn);
   };
 
   return (
@@ -93,47 +96,62 @@ export default function ConnectionTableServer() {
               <TableHead>Password</TableHead>
               <TableHead>DC</TableHead>
               <TableHead>Nodes</TableHead>
+              <TableHead />
             </TableRow>
           </TableHeader>
           <TableBody>
-            {connections.map((conn) => (
-              <TableRow key={conn.name}>
-                {[
-                  "status",
-                  "name",
-                  "host",
-                  "port",
-                  "username",
-                  "password",
-                  "dc",
-                  "nodes",
-                ].map((key) => (
-                  <ContextMenu key={`${conn.name}-${key}`}>
-                    <ContextMenuTrigger asChild>
-                      <TableCell>
-                        <TableLabel itemKey={key} conn={conn} />
-                      </TableCell>
-                    </ContextMenuTrigger>
-                    <ContextMenuContent>
-                      <ContextMenuItem onSelect={() => handleUpdateClick(conn)}>
-                        Update
-                      </ContextMenuItem>
-                      <ContextMenuItem onSelect={() => handleRefresh(conn)}>
-                        Refresh
-                      </ContextMenuItem>
-                      <ContextMenuItem onSelect={() => handleDelete(conn)}>
-                        Delete
-                      </ContextMenuItem>
-                    </ContextMenuContent>
-                  </ContextMenu>
-                ))}
-              </TableRow>
-            ))}
+            {!loadingConnections &&
+              availableConnections?.map((conn) => (
+                <TableRow key={conn.name}>
+                  {[
+                    "status",
+                    "name",
+                    "host",
+                    "port",
+                    "username",
+                    "password",
+                    "dc",
+                    "nodes",
+                    "actions",
+                  ].map((key) => (
+                    <ContextMenu key={`${conn.name}-${key}`}>
+                      <ContextMenuTrigger asChild>
+                        <TableCell>
+                          {key === "actions" ? (
+                            <RowActions connection={conn} />
+                          ) : (
+                            <TableLabel itemKey={key} conn={conn} />
+                          )}
+                        </TableCell>
+                      </ContextMenuTrigger>
+                      <ContextMenuContent>
+                        <ContextMenuItem
+                          onSelect={() => handleUpdateClick(conn)}
+                        >
+                          Update
+                        </ContextMenuItem>
+                        <ContextMenuItem onSelect={() => handleRefresh(conn)}>
+                          Refresh
+                        </ContextMenuItem>
+                        <ContextMenuItem onSelect={() => handleDelete(conn)}>
+                          Delete
+                        </ContextMenuItem>
+                      </ContextMenuContent>
+                    </ContextMenu>
+                  ))}
+                </TableRow>
+              ))}
           </TableBody>
         </Table>
+        {loadingConnections && (
+          <div className="flex flex-col gap-1 mt-1">
+            <Skeleton className="flex h-9" />
+            <Skeleton className="flex h-9" />
+          </div>
+        )}
         <NewConnectionModal
           onSave={handleSave}
-          connectionToEdit={selectedConnection}
+          connectionToEdit={currentConnection}
         />
       </CardContent>
     </Card>

--- a/src/app/(main)/connections/_components/modal.tsx
+++ b/src/app/(main)/connections/_components/modal.tsx
@@ -11,7 +11,7 @@ import {
 import { Input } from "@scylla-studio/components/ui/input";
 import { Modal } from "@scylla-studio/components/ui/modal";
 import { useLayout } from "@scylla-studio/contexts/layout";
-import { Plus } from "lucide-react";
+import { Loader2, Plus } from "lucide-react";
 import { type ReactNode, useEffect, useState, useTransition } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -81,15 +81,13 @@ export default function NewConnectionModal({
   const [isPending, startTransition] = useTransition();
 
   useEffect(() => {
-    if (connectionToEdit) {
-      setOpen(true);
-    }
+    if (connectionToEdit) setOpen(true);
   }, [connectionToEdit]);
 
   const handleSave = (data: z.infer<typeof formSchema>) => {
     startTransition(async () => {
       await onSave(data);
-      fetchInitialConnections();
+      await fetchInitialConnections();
       setOpen(false);
     });
   };
@@ -178,7 +176,13 @@ export default function NewConnectionModal({
             />
 
             <Button type="submit" disabled={isPending}>
-              {connectionToEdit ? "Update Connection" : "Save Connection"}
+              {isPending ? (
+                <Loader2 className="animate-spin" />
+              ) : connectionToEdit ? (
+                "Update Connection"
+              ) : (
+                "Save Connection"
+              )}
             </Button>
           </div>
         </FormWrapper>

--- a/src/app/(main)/connections/_components/row-actions.tsx
+++ b/src/app/(main)/connections/_components/row-actions.tsx
@@ -1,0 +1,66 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@scylla-studio/components/ui/dropdown-menu";
+import { useConnectionsStore } from "@scylla-studio/hooks/use-connections";
+import type { Connection } from "@scylla-studio/lib/internal-db/connections";
+import { EditIcon } from "lucide-react";
+import { toast } from "sonner";
+
+export const RowActions = ({
+  connection: conn,
+}: { connection: Connection }) => {
+  const { deleteConnection, refreshConnection, setCurrentConnection } =
+    useConnectionsStore();
+
+  const handleDelete = async () => {
+    try {
+      await deleteConnection(conn);
+      toast.success("Connection deleted successfully");
+    } catch (error) {
+      console.error("[ConnectionTableServer.handleDelete]", error);
+      toast.error("Error deleting connection, please try again later");
+    }
+  };
+
+  const handleRefresh = async () => {
+    try {
+      await refreshConnection(conn);
+      toast.success("Connection refreshed successfully");
+    } catch (error) {
+      console.error("[ConnectionTableServer.handleRefresh]", error);
+      toast.error("Error refreshing connection, please try again later");
+    }
+  };
+
+  const handleUpdate = () => {
+    setCurrentConnection(conn);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger>
+        <EditIcon size={16} className="cursor-pointer" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem onClick={handleUpdate} className="cursor-pointer">
+          Update
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleRefresh} className="cursor-pointer">
+          Refresh
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {/* styles to keep consistent in both themes */}
+        <DropdownMenuItem
+          onClick={handleDelete}
+          className="bg-red-600 focus:bg-red-500 focus:text-white text-white transition-all duration-300 cursor-pointer"
+        >
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/app/(main)/connections/_components/table-item.tsx
+++ b/src/app/(main)/connections/_components/table-item.tsx
@@ -1,7 +1,6 @@
 import { Badge } from "@scylla-studio/components/ui/badge";
 import { Label } from "@scylla-studio/components/ui/label";
-import { Connection } from "@scylla-studio/lib/internal-db/connections";
-import React from "react";
+import type { Connection } from "@scylla-studio/lib/internal-db/connections";
 
 export default function TableLabel({
   itemKey,

--- a/src/app/(main)/query-runner/_components/cql-editor.tsx
+++ b/src/app/(main)/query-runner/_components/cql-editor.tsx
@@ -13,6 +13,7 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@scylla-studio/components/ui/resizable";
+import { Skeleton } from "@scylla-studio/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@scylla-studio/components/ui/tabs";
 import { useCqlFilters } from "@scylla-studio/hooks/use-cql-filters";
 import type { AvailableConnections } from "@scylla-studio/lib/connections";
@@ -43,6 +44,7 @@ enum DisplayTabs {
 
 export function CqlEditor() {
   const [code, setCode] = useState("");
+  const [loadingResults, setLoadingResults] = useState(false);
   const [queryResult, setQueryResult] = useState<
     Array<Record<string, unknown>>
   >([]);
@@ -88,7 +90,7 @@ export function CqlEditor() {
     fetchSizeReference.current = fetchSize ?? null;
   }, [fetchSize]);
 
-  const executeQuery = (query: string) => {
+  const executeQuery = async (query: string) => {
     if (!currentConnectionReference.current) {
       toast.error("No connection selected");
       return;
@@ -105,11 +107,13 @@ export function CqlEditor() {
       password: password ?? null,
     };
 
-    queryExecutor.execute({
+    setLoadingResults(true);
+    await queryExecutor.executeAsync({
       query,
       connection,
       limit,
     });
+    setLoadingResults(false);
   };
 
   // Load saved query from localStorage when the component mounts
@@ -329,7 +333,14 @@ export function CqlEditor() {
               </TabsList>
             </Tabs>
           )}
-          {renderTabs[activeTab as DisplayTabs]}
+          {loadingResults ? (
+            <div className="flex flex-col w-full h-full gap-1 p-1">
+              <Skeleton className="h-11 w-full" />
+              <Skeleton className="h-full w-full" />
+            </div>
+          ) : (
+            renderTabs[activeTab as DisplayTabs]
+          )}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@scylla-studio/lib/utils";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/hooks/use-connections.ts
+++ b/src/hooks/use-connections.ts
@@ -1,0 +1,75 @@
+import {
+  updateConnection as dbUpdateConnection,
+  deleteConnection,
+  fetchConnections,
+  saveNewConnection,
+} from "@scylla-studio/app/(main)/connections/actions/connections";
+import type { Connection } from "@scylla-studio/lib/internal-db/connections";
+import { create } from "zustand";
+
+interface UseConnectionsStore {
+  availableConnections: Connection[];
+  currentConnection: Connection | null;
+
+  loadingConnections: boolean;
+  loadingDeleteConnection: boolean;
+  loadingSaveConnection: boolean;
+
+  setAvailableConnections: (connections: Connection[]) => void;
+  setCurrentConnection: (connection: Connection | null) => void;
+  getConnections: () => Promise<void>;
+  deleteConnection: (conn: Connection) => Promise<void>;
+  refreshConnection: (conn: Connection) => Promise<void>;
+  saveConnection: (conn: Connection) => Promise<void>;
+  updateConnection: (id: number, conn: Connection) => Promise<void>;
+}
+
+export const useConnectionsStore = create<UseConnectionsStore>((set) => ({
+  availableConnections: [],
+  currentConnection: null,
+
+  // ========== loading states ========== //
+  loadingConnections: false,
+  loadingDeleteConnection: false,
+  loadingSaveConnection: false,
+
+  setAvailableConnections: (connections: Connection[]) => {
+    set({ availableConnections: connections });
+  },
+  setCurrentConnection: (connection: Connection | null) => {
+    set({ currentConnection: connection });
+  },
+  getConnections: async () => {
+    set({ loadingConnections: true });
+    const updatedConnections = await fetchConnections();
+    set({ availableConnections: updatedConnections });
+    set({ loadingConnections: false });
+  },
+  deleteConnection: async (conn: Connection) => {
+    if (!conn.id) throw new Error("Connection ID not found");
+    set({ loadingDeleteConnection: true });
+    await deleteConnection(conn.id!);
+    set({ availableConnections: await fetchConnections() });
+    set({ loadingDeleteConnection: false });
+  },
+  refreshConnection: async (conn: Connection) => {
+    if (!conn.id) throw new Error("Connection ID not found");
+    await dbUpdateConnection(conn.id!, conn);
+    set({ availableConnections: await fetchConnections() });
+  },
+  saveConnection: async (conn: Connection) => {
+    set({ loadingSaveConnection: true });
+    await saveNewConnection(conn);
+    set({ availableConnections: await fetchConnections() });
+    set({ loadingSaveConnection: false });
+    set({ currentConnection: null });
+  },
+  updateConnection: async (id: number, conn: Connection) => {
+    if (!id) throw new Error("Connection ID not found");
+    set({ loadingSaveConnection: true });
+    await dbUpdateConnection(id, conn);
+    set({ availableConnections: await fetchConnections() });
+    set({ loadingSaveConnection: false });
+    set({ currentConnection: null });
+  },
+}));

--- a/src/lib/internal-db/connections.ts
+++ b/src/lib/internal-db/connections.ts
@@ -23,12 +23,12 @@ db.exec(`
   )
 `);
 
-db.exec(`
-  INSERT OR IGNORE INTO connections
-    (id, name, status, host, port, username, password, dc, nodes)
-  VALUES
-    (1, 'ScyllaDB Localhost', 'Offline', 'localhost', '9042', null, null, 'local', 1)
-`);
+// db.exec(`
+//   INSERT OR IGNORE INTO connections
+//     (id, name, status, host, port, username, password, dc, nodes)
+//   VALUES
+//     (1, 'ScyllaDB Localhost', 'Offline', 'localhost', '9042', null, null, 'local', 1)
+// `);
 
 export async function getAllConnections(): Promise<Connection[]> {
   return db
@@ -73,7 +73,7 @@ export function updateConnectionById(
   );
 }
 
-export function deleteConnectionById(connectionId: number) {
+export async function deleteConnectionById(connectionId: number) {
   const stmt = db.prepare(`
     DELETE FROM connections WHERE id = ?
   `);

--- a/src/lib/menu-list.ts
+++ b/src/lib/menu-list.ts
@@ -1,14 +1,15 @@
+"use client";
+
 import { SelectKeySpace } from "@scylla-studio/components/composed/select-database";
 import { useLayout } from "@scylla-studio/contexts/layout";
 import {
   Cable,
   CodeSquare,
   HomeIcon,
-  LayoutGrid,
   type LucideIcon,
   TableProperties,
 } from "lucide-react";
-import { type ReactNode, useEffect } from "react";
+import { type ReactNode, startTransition, useEffect } from "react";
 
 type Submenu = {
   href: string;
@@ -43,13 +44,10 @@ export function useGetMenuList(pathname: string): Group[] {
   const queryKeyspace = useLayout((state) => state.queryKeyspace);
 
   useEffect(() => {
-    fetchInitialConnections();
-    const fetchKeyspace = async () => {
-      if (selectedConnection) {
-        await queryKeyspace(selectedConnection!);
-      }
-    };
-    fetchKeyspace();
+    startTransition(async () => {
+      await fetchInitialConnections();
+      if (selectedConnection) await queryKeyspace(selectedConnection!);
+    });
   }, [selectedConnection, fetchInitialConnections, queryKeyspace]);
 
   const keyspaceList = Object.entries(keyspaces).map(([keyspaceName]) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Pauses the execution for a specified number of seconds.
+ *
+ * @param seconds - The number of seconds to sleep.
+ * @returns A promise that resolves after the specified number of seconds.
+ */
+export const sleep = async (seconds: number): Promise<void> => {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+};


### PR DESCRIPTION
This pull request closes #44 and includes significant refactoring and improvements to the connections management and query execution functionalities. The most important changes involve migrating state management to a custom hook, enhancing user feedback with loading states, and refactoring the connection table component to improve code readability and maintainability.

### Refactoring and State Management:

* [`src/app/(main)/connections/_components/connection-table.tsx`](diffhunk://#diff-fc821585abd5135454d3443bcc5921ff660979bb39fa87e079319ebcbca8738fR23-R79): Refactored to use `useConnectionsStore` for state management, removing local state and actions. Added loading states and error handling for connection operations. [[1]](diffhunk://#diff-fc821585abd5135454d3443bcc5921ff660979bb39fa87e079319ebcbca8738fR23-R79) [[2]](diffhunk://#diff-fc821585abd5135454d3443bcc5921ff660979bb39fa87e079319ebcbca8738fR99-R104) [[3]](diffhunk://#diff-fc821585abd5135454d3443bcc5921ff660979bb39fa87e079319ebcbca8738fR115-R130)
* [`src/hooks/use-connections.ts`](diffhunk://#diff-7e70faaed18fd476d5a39f61123c86a33712fcf2a7a349b9345d9fd0ddb128a4R1-R75): Created a custom hook `useConnectionsStore` to manage connection states and operations, including fetching, deleting, refreshing, saving, and updating connections.

### User Feedback Enhancements:

* [`src/app/(main)/connections/_components/connection-table.tsx`](diffhunk://#diff-fc821585abd5135454d3443bcc5921ff660979bb39fa87e079319ebcbca8738fR146-R154): Added `Skeleton` components to display loading states for connections.
* [`src/app/(main)/query-runner/_components/cql-editor.tsx`](diffhunk://#diff-c3d008cee84b65d82023278c89d53a325b14f0df0e41dfe05a6b97bc57e63f16R47): Added loading state for query results and used `Skeleton` components to indicate loading. [[1]](diffhunk://#diff-c3d008cee84b65d82023278c89d53a325b14f0df0e41dfe05a6b97bc57e63f16R47) [[2]](diffhunk://#diff-c3d008cee84b65d82023278c89d53a325b14f0df0e41dfe05a6b97bc57e63f16L332-R343)

### Component and Import Improvements:

* [`src/app/(main)/connections/_components/row-actions.tsx`](diffhunk://#diff-dac9fed6f9f19ac8e1f33cc4f000378458734ed7422ede1cfb9fafd788bcda65R1-R66): Created a new `RowActions` component to handle connection actions (update, refresh, delete) with user feedback.
* [`src/actions/query-keyspaces.ts`](diffhunk://#diff-a1f9a04cf79cd6866c983360bc0bd78dd58e57c14e843bd31bc8c5281d4bdea2L6-R6): Updated import to use `type` keyword for type-only imports.

### Miscellaneous Changes:

* [`src/lib/internal-db/connections.ts`](diffhunk://#diff-732f3dd0028a7e36767d25261b94a842f5ea96e86ddefc683d274a1267c4ad6eL26-R31): Commented out initial connection insertion and made `deleteConnectionById` asynchronous. [[1]](diffhunk://#diff-732f3dd0028a7e36767d25261b94a842f5ea96e86ddefc683d274a1267c4ad6eL26-R31) [[2]](diffhunk://#diff-732f3dd0028a7e36767d25261b94a842f5ea96e86ddefc683d274a1267c4ad6eL76-R76)
* [`src/app/(main)/connections/_components/modal.tsx`](diffhunk://#diff-103521702ecaedc83e97eecf1240316419142813b3a762d1aa9be813bbb20a19L84-R90): Simplified `useEffect` for opening the modal and added a loading spinner to the save button. [[1]](diffhunk://#diff-103521702ecaedc83e97eecf1240316419142813b3a762d1aa9be813bbb20a19L84-R90) [[2]](diffhunk://#diff-103521702ecaedc83e97eecf1240316419142813b3a762d1aa9be813bbb20a19L181-R185)

These changes collectively improve the codebase by enhancing user experience, improving state management, and making the components more modular and maintainable.