### PR TITLE
feat: add dependabot cfg for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    allow:
+      - dependency-type: "production"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
This pull request includes changes to configure Dependabot for automated dependency updates. The configuration specifies the ecosystems for npm and GitHub Actions, along with their respective update schedules and rules.

Dependabot configuration:

* Added configuration for npm dependencies to be updated daily, ignoring major version updates, and allowing only production dependencies.
* Added configuration for GitHub Actions dependencies to be updated weekly, ignoring major version updates.

> [!WARNING]
> It's possible that when the merge is complete, the dependabot will create a bunch of pull requests and do not just close the PR, or dependabot will ignore the update for that dependency unless we re-enable the PR or do a manual update.

![image](https://github.com/user-attachments/assets/0ab2bd00-ba9b-4197-9ce3-01b38b149628)
