### PR TITLE
feat(cql-editor): keyspace/table autocompleter #48 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "unicorn/no-array-for-each": 0,
     "unicorn/no-nested-ternary": 0,
     "unicorn/prefer-spread": 0,
+    "unicorn/no-array-reduce": 0,
     "unicorn/prevent-abbreviations": 0,
     // TODO: Check these rules later
     "@typescript-eslint/no-explicit-any": 0,

--- a/src/app/(main)/query-runner/_components/cql-autocompleter.ts
+++ b/src/app/(main)/query-runner/_components/cql-autocompleter.ts
@@ -1,15 +1,14 @@
 import { ScyllaKeyspace } from "@lambda-group/scylladb";
 import { useMonaco } from "@monaco-editor/react";
 import KeyspaceDefinitions from "@scylla-studio/app/(main)/keyspace/[keyspace]/_components/keyspace-tables";
-import { getFullQueryAtCursor, getSingleLineQueryAtCursor } from "@scylla-studio/app/(main)/query-runner/_components/utils";
+import {
+  getFullQueryAtCursor,
+  getSingleLineQueryAtCursor,
+} from "@scylla-studio/app/(main)/query-runner/_components/utils";
 import { useCqlFilters } from "@scylla-studio/hooks/use-cql-filters";
 import { KeyspaceDefinition } from "@scylla-studio/lib/cql-parser/keyspace-parser";
 import { TableDefinition } from "@scylla-studio/lib/cql-parser/table-parser";
-import {
-
-  editor,
-  languages,
-} from "monaco-editor";
+import { editor, languages } from "monaco-editor";
 
 export type MonacoInstance = NonNullable<ReturnType<typeof useMonaco>>;
 
@@ -304,14 +303,12 @@ export const cqlCompletionItemProvider = (
   monacoInstance: MonacoInstance,
   editor: editor.IStandaloneCodeEditor,
   keyspaces?: KeyspaceDefinition[],
-  keyspacesTables?: TableCompletion[]
+  keyspacesTables?: TableCompletion[],
 ): languages.CompletionItem[] => {
-
-
   const cursor = getSingleLineQueryAtCursor(editor, monacoInstance);
   if (!cursor) return getDefaultSuggestions(monacoInstance);
-  const textUntilPosition = cursor.query.split("\n\n").shift()?.replaceAll(";", "") || "";
-
+  const textUntilPosition =
+    cursor.query.split("\n\n").shift()?.replaceAll(";", "") || "";
 
   const useKeyspaceRegex = /USE\s+(\w*)$/i;
   const fromTableRegex = /FROM\s+(\w*)$/i;
@@ -319,10 +316,12 @@ export const cqlCompletionItemProvider = (
   const whereColumnRegex = /WHERE\s+(\w*)$/i;
   // Check if you're typing a keyspace
   if (useKeyspaceRegex.test(textUntilPosition)) {
-
-    return prepareUseSuggestions(monacoInstance, (keyspaces as any) as KeyspaceDefinition[] || []);
+    return prepareUseSuggestions(
+      monacoInstance,
+      (keyspaces as any as KeyspaceDefinition[]) || [],
+    );
   } else if (fromTableRegex.test(textUntilPosition)) {
-    return prepareTablesSuggestions(monacoInstance, keyspacesTables  || []);
+    return prepareTablesSuggestions(monacoInstance, keyspacesTables || []);
   } else if (selectColumnRegex.test(textUntilPosition)) {
     // TODO: or we display everything related to all tables or we display nothing
     return getDefaultSuggestions(monacoInstance);

--- a/src/app/(main)/query-runner/_components/cql-editor.tsx
+++ b/src/app/(main)/query-runner/_components/cql-editor.tsx
@@ -366,7 +366,7 @@ export function CqlEditor() {
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
-          {currentConnection && isFecthedKeys && (
+          {currentConnection && isFetchedKeys && (
             <Editor
               height="100%"
               theme="vs-dark"

--- a/src/app/(main)/query-runner/_components/cql-editor.tsx
+++ b/src/app/(main)/query-runner/_components/cql-editor.tsx
@@ -63,7 +63,7 @@ export function CqlEditor() {
   const [keyspaces, setKeyspaces] = useState<Record<string, ScyllaKeyspace>>(
     {},
   );
-  const [isFecthedKeys, setIsFecthecKeys] = useState(false);
+  const [isFetchedKeys, setIsFetchedKeys] = useState(false);
   const [queryResult, setQueryResult] = useState<
     Array<Record<string, unknown>>
   >([]);

--- a/src/app/(main)/query-runner/_components/cql-editor.tsx
+++ b/src/app/(main)/query-runner/_components/cql-editor.tsx
@@ -293,7 +293,7 @@ export function CqlEditor() {
       toast.error("Failed to query keyspaces.");
       console.error(error);
     } finally {
-      setIsFecthecKeys(true);
+      setIsFetchedKeys(true);
     }
   };
 


### PR DESCRIPTION
This pull request includes several changes to improve the functionality of the CQL editor and autocompleter. The main changes involve adding new utility functions, updating the completion item provider, and querying keyspaces for better suggestions.

### Improvements to CQL Editor and Autocompleter

* **New Imports and Utility Functions**:
  * Added imports for `ScyllaKeyspace` and `getSingleLineQueryAtCursor` in `cql-autocompleter.ts` and `cql-editor.tsx`. [[1]](diffhunk://#diff-5feb6defb1e3d8fa5b864f5eb133be4704cd4a41d6d808d688c8d4c0eb4fb579R1-R9) [[2]](diffhunk://#diff-c3d008cee84b65d82023278c89d53a325b14f0df0e41dfe05a6b97bc57e63f16R3-R6)
  * Introduced `getSingleLineQueryAtCursor`, `formatKeyspaces`, and `formatKeyspacesTables` utility functions in `utils.tsx` to handle keyspace and table formatting.

* **Completion Item Provider Enhancements**:
  * Updated `cqlCompletionItemProvider` to use `getSingleLineQueryAtCursor` for improved query handling and added parameters for keyspaces and tables.
  * Modified the logic to use real keyspace and table data for suggestions.

* **CQL Editor Enhancements**:
  * Added state management for keyspaces and a function to query keyspaces from the server. [[1]](diffhunk://#diff-c3d008cee84b65d82023278c89d53a325b14f0df0e41dfe05a6b97bc57e63f16R63-R66) [[2]](diffhunk://#diff-c3d008cee84b65d82023278c89d53a325b14f0df0e41dfe05a6b97bc57e63f16R277-R299)
  * Updated the editor to provide completion items using the formatted keyspaces and tables.
  * Included a conditional rendering of the editor based on the keyspaces fetch status. [[1]](diffhunk://#diff-c3d008cee84b65d82023278c89d53a325b14f0df0e41dfe05a6b97bc57e63f16R369) [[2]](diffhunk://#diff-c3d008cee84b65d82023278c89d53a325b14f0df0e41dfe05a6b97bc57e63f16R385)

* **ESLint Configuration**:
  * Disabled the `unicorn/no-array-reduce` rule in `.eslintrc.json` to allow the use of `reduce` in the new utility functions.