### PR TITLE
chore: group dependabot updates and enable `dev-deps`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+    groups:
+      prod-dependencies:
+        dependency-type: production
+        patterns:
+          - "*"
+      dev-dependencies:
+        dependency-type: development
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-    allow:
-      - dependency-type: "production"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request includes a change to `dependabot` to improve the organization of dependency updates. It will re-enable dev dependency updates and group each type of `dev/prod' into one pull request.

> [!WARNING]
> With that, we can expect a pull request for each type. But can be more difficult to track if the dependencies have breaking changes. We are ignoring `major` updates but `minor` can also make some changes on exposed api.

---

> [!WARNING]
> Since we previously ignored the `dev-dependencies`, some updates have accumulated.
> 
> ![image](https://github.com/user-attachments/assets/70aff956-18bb-4f42-80b6-7ce2f80e4681)


